### PR TITLE
Release v1.0.1 - Maintenance Update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1] - 2025-07-21
+
+### 🧹 **Maintenance**
+
+- **Removed deprecated `.path()` method** - Completed deprecation cycle started in v0.2.7, method fully removed from codebase
+- **Updated tests** - Migrated all test code from deprecated `.path()` to modern deref patterns (`&app_path`)
+- **Improved documentation examples** - Corrected and clarified examples throughout the codebase
+
+### 📚 **Documentation**
+
+- **Enhanced code examples** - Better clarity and accuracy in documentation examples
+- **Test suite cleanup** - Ensured all tests use current API patterns without deprecated methods
+
 ## [1.0.0] - 2025-07-20
 
 ### 🎉 **STABLE RELEASE** - Production Ready API

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app-path"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 authors = ["David Krasnitsky <dikaveman@gmail.com>"]
 description = "Create file paths relative to your executable for truly portable applications"

--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ Simple, zero-dependency library for creating portable applications where configu
 use app_path::app_path;
 
 // Files relative to your executable - not current directory!
-let config = app_path!("config.toml");        // → /path/to/exe/config.toml
-let database = app_path!("data/users.db");    // → /path/to/exe/data/users.db
+let config = app_path!("config.toml");      // → /path/to/exe_dir/config.toml
+let database = app_path!("data/users.db");  // → /path/to/exe_dir/data/users.db
 
 // Environment override for deployment
 let logs = app_path!("logs/app.log", env = "LOG_PATH");
-// → Uses LOG_PATH if set, otherwise /path/to/exe/logs/app.log
+// → Uses LOG_PATH if set, otherwise /path/to/exe_dir/logs/app.log
 
 // Acts like std::path::Path + creates directories
 if !config.exists() {
@@ -54,7 +54,7 @@ if !config.exists() {
 use app_path::app_path;
 
 // Application base directory
-let app_base = app_path!();                     // → /path/to/exe/
+let app_base = app_path!();  // → /path/to/exe_dir/
 
 // Simple paths
 let config = app_path!("config.toml");
@@ -83,8 +83,8 @@ let version = "1.0";
 let versioned_cache = app_path!(format!("cache-{version}"));
 
 // Directory creation
-logs.create_parents()?;              // Creates logs/ for the file
-app_path!("temp").create_dir()?;     // Creates temp/ directory itself
+app_path!("logs/app.log").create_parents()?;  // Creates `logs/` for the `app.log` file
+app_path!("temp").create_dir()?;  // Creates `temp/` directory itself
 ```
 
 ### Fallible `try_app_path!` Macro
@@ -92,7 +92,8 @@ app_path!("temp").create_dir()?;     // Creates temp/ directory itself
 ```rust
 use app_path::try_app_path;
 
-let app_base = try_app_path!()?;                                     // Fallible base directory
+// Fallible base directory
+let app_base = try_app_path!()?;  
 let config = try_app_path!("config.toml")?;
 let database = try_app_path!("data/users.db", env = "DATABASE_PATH")?;
 
@@ -109,9 +110,9 @@ match try_app_path!("logs/app.log") {
 use app_path::AppPath;
 
 // Basic constructors
-let app_base = AppPath::new();                          // Executable directory
-let config = AppPath::with("config.toml");              // App base + path
-let database = AppPath::try_with("data/users.db")?;     // Fallible version
+let app_base = AppPath::new();                       // Executable directory
+let config = AppPath::with("config.toml");           // App base + path
+let database = AppPath::try_with("data/users.db")?;  // Fallible version
 
 // Override constructors
 let config = AppPath::with_override("config.toml", std::env::var("CONFIG_PATH").ok());
@@ -186,7 +187,7 @@ This design makes sense because if the system can't determine your executable lo
 use app_path::{AppPath, AppPathError};
 
 // Libraries should handle errors explicitly
-match AppPath::try_new("config.toml") {
+match AppPath::try_with("config.toml") {
     Ok(path) => println!("Config: {}", path.display()),
     Err(AppPathError::ExecutableNotFound(msg)) => {
         eprintln!("Cannot find executable: {msg}");
@@ -203,10 +204,10 @@ match AppPath::try_new("config.toml") {
 
 ### 🔗 **Popular Path Crate Compatibility**
 
-| Crate                                                   | Use Case                           | Integration Pattern                |
-| ------------------------------------------------------- | ---------------------------------- | ---------------------------------- |
+| Crate                                                   | Use Case                           | Integration Pattern                            |
+| ------------------------------------------------------- | ---------------------------------- | ---------------------------------------------- |
 | **[`camino`](https://crates.io/crates/camino)**         | UTF-8 path guarantees for web apps | `Utf8PathBuf::from_path_buf(app_path.into())?` |
-| **[`typed-path`](https://crates.io/crates/typed-path)** | Cross-platform type-safe paths     | `WindowsPath::new(app_path.to_bytes())` |
+| **[`typed-path`](https://crates.io/crates/typed-path)** | Cross-platform type-safe paths     | `WindowsPath::new(app_path.to_bytes())`        |
 
 ### 📝 **Real-World Integration Examples**
 

--- a/src/app_path/constructors.rs
+++ b/src/app_path/constructors.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use crate::{try_exe_dir, AppPath, AppPathError};
 
@@ -207,8 +207,8 @@ impl AppPath {
     ///     let data = AppPath::try_with("data/app.db")?;
     ///     
     ///     // Initialize application with these paths
-    ///     println!("Config: {}", config.path().display());
-    ///     println!("Data: {}", data.path().display());
+    ///     println!("Config: {}", config.display());
+    ///     println!("Data: {}", data.display());
     ///     
     ///     Ok(())
     /// }
@@ -277,21 +277,6 @@ impl AppPath {
         let exe_dir = try_exe_dir()?;
         let full_path = exe_dir.join(path);
         Ok(Self { full_path })
-    }
-
-    /// Creates an AppPath from an absolute path.
-    ///
-    /// This is an internal helper for operations that need to create AppPath
-    /// instances from already-resolved absolute paths (like join, with_extension, etc).
-    ///
-    /// # Arguments
-    ///
-    /// * `path` - An absolute path that will be stored directly
-    #[inline]
-    pub(crate) fn from_absolute_path(path: impl Into<PathBuf>) -> Self {
-        Self {
-            full_path: path.into(),
-        }
     }
 
     /// Creates file paths relative to the application's base directory.

--- a/src/app_path/path_ops.rs
+++ b/src/app_path/path_ops.rs
@@ -3,37 +3,6 @@ use std::path::Path;
 use crate::AppPath;
 
 impl AppPath {
-    /// Get the full resolved path.
-    ///
-    /// This is the primary method for getting the actual filesystem path
-    /// where your file or directory is located.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use app_path::AppPath;
-    ///
-    /// let config = AppPath::with("config.toml");
-    ///
-    /// // For displaying paths - use Display trait
-    /// println!("Config path: {}", config.display());
-    ///
-    /// // For getting &Path reference - use deref
-    /// assert!(config.is_absolute());
-    ///
-    /// // For functions expecting &Path - use as_ref() or &config
-    /// std::fs::write(&config, "content")?;
-    /// # Ok::<(), std::io::Error>(())
-    /// ```
-    #[deprecated(
-        since = "0.2.7",
-        note = "Use `&app_path` or `app_path.as_ref()` instead. AppPath implements Deref<Target=Path>, so all Path methods are directly available."
-    )]
-    #[inline]
-    pub fn path(&self) -> &Path {
-        &self.full_path
-    }
-
     /// Joins additional path segments to create a new AppPath.
     ///
     /// This creates a new `AppPath` by joining the current path with additional segments.
@@ -55,7 +24,9 @@ impl AppPath {
     /// ```
     #[inline]
     pub fn join(&self, path: impl AsRef<Path>) -> Self {
-        Self::from_absolute_path(self.full_path.join(path))
+        Self {
+            full_path: self.full_path.join(path),
+        }
     }
 
     /// Returns the parent directory as an AppPath, if it exists.
@@ -75,7 +46,7 @@ impl AppPath {
     /// ```
     #[inline]
     pub fn parent(&self) -> Option<Self> {
-        self.full_path.parent().map(Self::from_absolute_path)
+        self.full_path.parent().map(Self::with)
     }
 
     /// Creates a new AppPath with the specified file extension.
@@ -97,7 +68,7 @@ impl AppPath {
     /// ```
     #[inline]
     pub fn with_extension(&self, ext: &str) -> Self {
-        Self::from_absolute_path(self.full_path.with_extension(ext))
+        Self::with(self.full_path.with_extension(ext))
     }
 
     /// Consumes the `AppPath` and returns the internal `PathBuf`.

--- a/src/error.rs
+++ b/src/error.rs
@@ -34,7 +34,7 @@ use std::path::PathBuf;
 /// // Handle errors explicitly
 /// match AppPath::try_with("config.toml") {
 ///     Ok(config) => {
-///         println!("Config path: {}", config.path().display());
+///         println!("Config path: {}", config.display());
 ///     }
 ///     Err(AppPathError::ExecutableNotFound(msg)) => {
 ///         eprintln!("Cannot find executable: {msg}");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,12 +8,12 @@
 //! use app_path::app_path;
 //!
 //! // Files relative to your executable - not current directory!
-//! let config = app_path!("config.toml");        // → /path/to/exe/config.toml
-//! let database = app_path!("data/users.db");    // → /path/to/exe/data/users.db
+//! let config = app_path!("config.toml");     // → /path/to/exe_dir/config.toml
+//! let database = app_path!("data/users.db"); // → /path/to/exe_dir/data/users.db
 //!
 //! // Environment overrides for deployment
 //! let logs = app_path!("logs/app.log", env = "LOG_PATH");
-//! // → Uses LOG_PATH if set, otherwise /path/to/exe/logs/app.log
+//! // → Uses LOG_PATH if set, otherwise /path/to/exe_dir/logs/app.log
 //!
 //! // Works like standard paths - all Path methods available
 //! if config.exists() {
@@ -21,8 +21,8 @@
 //! }
 //!
 //! // Directory creation
-//! logs.create_parents()?;                 // Creates logs/ directory for the file
-//! app_path!("cache").create_dir()?;       // Creates cache/ directory itself
+//! logs.create_parents()?;            // Creates logs/ directory for the file
+//! app_path!("cache").create_dir()?;  // Creates cache/ directory itself
 //! # Ok::<(), Box<dyn std::error::Error>>(())
 //! ```
 //!
@@ -86,21 +86,21 @@
 //! # use app_path::{app_path, try_app_path};
 //! // 1. Direct value
 //! let config = app_path!("config.toml");
-//! // → /path/to/exe/config.toml
+//! // → /path/to/exe_dir/config.toml
 //!
 //! // 2. With environment override
 //! let config = app_path!("config.toml", env = "CONFIG_PATH");
-//! // → Uses CONFIG_PATH if set, otherwise /path/to/exe/config.toml
+//! // → Uses CONFIG_PATH if set, otherwise /path/to/exe_dir/config.toml
 //!
 //! // 3. With optional override value
 //! let config = app_path!("config.toml", override = std::env::var("CONFIG_PATH").ok());
-//! // → Uses CONFIG_PATH if available, otherwise /path/to/exe/config.toml
+//! // → Uses CONFIG_PATH if available, otherwise /path/to/exe_dir/config.toml
 //!
 //! // 4. With function-based override
 //! let config = app_path!("config.toml", fn = || {
 //!     std::env::var("CONFIG_PATH").ok()
 //! });
-//! // → Uses function result if Some, otherwise /path/to/exe/config.toml
+//! // → Uses function result if Some, otherwise /path/to/exe_dir/config.toml
 //! ```
 //!
 //! ### Variable Capturing in Macros

--- a/src/tests/constructors.rs
+++ b/src/tests/constructors.rs
@@ -13,14 +13,14 @@ fn test_new_constructor() {
     // Should match what std::env::current_exe() tells us (independent verification)
     let current_exe = std::env::current_exe().unwrap();
     let exe_parent = current_exe.parent().unwrap();
-    assert_eq!(app_base.path(), exe_parent);
+    assert_eq!(&*app_base, exe_parent);
 
     // Should be a directory, not a file
     assert!(app_base.is_dir());
 
     // Should be consistent across multiple calls (caching)
     let app_base2 = AppPath::new();
-    assert_eq!(app_base.path(), app_base2.path());
+    assert_eq!(app_base, app_base2);
 }
 
 #[test]
@@ -36,11 +36,11 @@ fn test_try_new_constructor() {
     // Should match what std::env::current_exe() tells us (independent verification)
     let current_exe = std::env::current_exe().unwrap();
     let exe_parent = current_exe.parent().unwrap();
-    assert_eq!(app_base.path(), exe_parent);
+    assert_eq!(&*app_base, exe_parent);
 
     // Should be consistent with panicking version
     let panicking_version = AppPath::new();
-    assert_eq!(app_base.path(), panicking_version.path());
+    assert_eq!(app_base, panicking_version);
 
     // Should be a directory, not a file
     assert!(app_base.is_dir());
@@ -60,15 +60,15 @@ fn test_new_with_different_types() {
     let from_path_ref = AppPath::from(Path::new("test.txt"));
 
     // All should produce equivalent results
-    assert_eq!(from_str.path(), from_string.path());
-    assert_eq!(from_string.path(), from_path_buf.path());
-    assert_eq!(from_path_buf.path(), from_path_ref.path());
+    assert_eq!(&from_str, &from_string);
+    assert_eq!(&from_string, &from_path_buf);
+    assert_eq!(&from_path_buf, &from_path_ref);
 
     // Should all resolve to exe_dir + filename (independent verification)
     let current_exe = std::env::current_exe().unwrap();
     let exe_parent = current_exe.parent().unwrap();
     let expected = exe_parent.join("test.txt");
-    assert_eq!(from_str.path(), &expected);
+    assert_eq!(&*from_str, expected);
 }
 
 #[test]
@@ -82,7 +82,7 @@ fn test_ownership_transfer() {
     let current_exe = std::env::current_exe().unwrap();
     let exe_parent = current_exe.parent().unwrap();
     let expected = exe_parent.join("test.txt");
-    assert_eq!(app_path.path(), &expected);
+    assert_eq!(&*app_path, expected);
 
     // Test with String too
     let string_path = "another_test.txt".to_string();
@@ -90,7 +90,7 @@ fn test_ownership_transfer() {
     // string_path is moved and no longer accessible
 
     let expected2 = exe_parent.join("another_test.txt");
-    assert_eq!(app_path2.path(), &expected2);
+    assert_eq!(&*app_path2, expected2);
 }
 
 #[test]
@@ -110,12 +110,12 @@ fn test_from_implementations() {
     let from_pathbuf_ref: AppPath = (&PathBuf::from("test.txt")).into();
 
     // All should produce the same result
-    assert_eq!(from_str.path(), &expected);
-    assert_eq!(from_string.path(), &expected);
-    assert_eq!(from_string_ref.path(), &expected);
-    assert_eq!(from_path.path(), &expected);
-    assert_eq!(from_pathbuf.path(), &expected);
-    assert_eq!(from_pathbuf_ref.path(), &expected);
+    assert_eq!(&*from_str, &expected);
+    assert_eq!(&*from_string, &expected);
+    assert_eq!(&*from_string_ref, &expected);
+    assert_eq!(&*from_path, &expected);
+    assert_eq!(&*from_pathbuf, &expected);
+    assert_eq!(&*from_pathbuf_ref, &expected);
 }
 
 #[test]
@@ -125,7 +125,7 @@ fn test_from_str() {
     let exe_parent = current_exe.parent().unwrap();
     let expected = exe_parent.join("config.toml");
 
-    assert_eq!(rel_path.path(), &expected);
+    assert_eq!(&*rel_path, &expected);
 }
 
 #[test]
@@ -136,7 +136,7 @@ fn test_from_string() {
     let exe_parent = current_exe.parent().unwrap();
     let expected = exe_parent.join("data/file.txt");
 
-    assert_eq!(rel_path.path(), &expected);
+    assert_eq!(&*rel_path, &expected);
 }
 
 #[test]
@@ -147,7 +147,7 @@ fn test_from_string_ref() {
     let exe_parent = current_exe.parent().unwrap();
     let expected = exe_parent.join("logs/app.log");
 
-    assert_eq!(rel_path.path(), &expected);
+    assert_eq!(&*rel_path, &expected);
 }
 
 // === Fallible API Tests ===
@@ -159,11 +159,11 @@ fn test_try_with_success() {
     let current_exe = std::env::current_exe().unwrap();
     let exe_parent = current_exe.parent().unwrap();
     let expected = exe_parent.join("config.toml");
-    assert_eq!(config.path(), &expected);
+    assert_eq!(&*config, &expected);
 
     let data = AppPath::try_with("data/users.db").unwrap();
     let expected = exe_parent.join("data/users.db");
-    assert_eq!(data.path(), &expected);
+    assert_eq!(&*data, &expected);
 }
 
 #[test]
@@ -182,12 +182,12 @@ fn test_try_with_different_types() {
     let current_exe = std::env::current_exe().unwrap();
     let exe_parent = current_exe.parent().unwrap();
     let expected = exe_parent.join("config.toml");
-    assert_eq!(from_str.path(), &expected);
-    assert_eq!(from_string.path(), &expected);
-    assert_eq!(from_string_ref.path(), &expected);
-    assert_eq!(from_path.path(), &expected);
-    assert_eq!(from_pathbuf.path(), &expected);
-    assert_eq!(from_pathbuf_ref.path(), &expected);
+    assert_eq!(&*from_str, &expected);
+    assert_eq!(&*from_string, &expected);
+    assert_eq!(&*from_string_ref, &expected);
+    assert_eq!(&*from_path, &expected);
+    assert_eq!(&*from_pathbuf, &expected);
+    assert_eq!(&*from_pathbuf_ref, &expected);
 }
 
 // === Override Constructor Tests ===
@@ -200,7 +200,7 @@ fn test_with_override_some() {
     let custom_path = temp_dir.join("custom_config.toml");
 
     let config = AppPath::with_override("default.toml", Some(&custom_path));
-    assert_eq!(config.path(), custom_path);
+    assert_eq!(&*config, &custom_path);
 }
 
 #[test]
@@ -211,7 +211,7 @@ fn test_with_override_none() {
     let current_exe = std::env::current_exe().unwrap();
     let exe_parent = current_exe.parent().unwrap();
     let expected = exe_parent.join("default.toml");
-    assert_eq!(config.path(), &expected);
+    assert_eq!(&*config, &expected);
 }
 
 #[test]
@@ -222,7 +222,7 @@ fn test_try_with_override_some() {
     let custom_path = temp_dir.join("custom_config.toml");
 
     let config = AppPath::try_with_override("default.toml", Some(&custom_path)).unwrap();
-    assert_eq!(config.path(), custom_path);
+    assert_eq!(&*config, &custom_path);
 }
 
 #[test]
@@ -233,7 +233,7 @@ fn test_try_with_override_none() {
     let current_exe = std::env::current_exe().unwrap();
     let exe_parent = current_exe.parent().unwrap();
     let expected = exe_parent.join("default.toml");
-    assert_eq!(config.path(), &expected);
+    assert_eq!(&*config, &expected);
 }
 
 #[test]
@@ -244,7 +244,7 @@ fn test_with_override_fn_some() {
     let custom_path = temp_dir.join("custom_fn.toml");
 
     let config = AppPath::with_override_fn("default.toml", || Some(custom_path.clone()));
-    assert_eq!(config.path(), custom_path);
+    assert_eq!(&*config, &custom_path);
 }
 
 #[test]
@@ -255,7 +255,7 @@ fn test_with_override_fn_none() {
     let current_exe = std::env::current_exe().unwrap();
     let exe_parent = current_exe.parent().unwrap();
     let expected = exe_parent.join("default.toml");
-    assert_eq!(config.path(), &expected);
+    assert_eq!(&*config, &expected);
 }
 
 #[test]
@@ -267,7 +267,7 @@ fn test_try_with_override_fn_some() {
 
     let config =
         AppPath::try_with_override_fn("default.toml", || Some(custom_path.clone())).unwrap();
-    assert_eq!(config.path(), custom_path);
+    assert_eq!(&*config, &custom_path);
 }
 
 #[test]
@@ -278,7 +278,7 @@ fn test_try_with_override_fn_none() {
     let current_exe = std::env::current_exe().unwrap();
     let exe_parent = current_exe.parent().unwrap();
     let expected = exe_parent.join("default.toml");
-    assert_eq!(config.path(), &expected);
+    assert_eq!(&*config, &expected);
 }
 
 // === API Consistency Tests ===
@@ -303,6 +303,6 @@ fn test_caching_consistency() {
     let second_call = AppPath::try_new().unwrap();
     let third_call = AppPath::new();
 
-    assert_eq!(first_call.path(), second_call.path());
-    assert_eq!(second_call.path(), third_call.path());
+    assert_eq!(&*first_call, &*second_call);
+    assert_eq!(&*second_call, &*third_call);
 }

--- a/src/tests/error_handling.rs
+++ b/src/tests/error_handling.rs
@@ -65,7 +65,7 @@ fn test_fallible_api_documentation_examples() {
     // Example 1: Basic error handling pattern
     match AppPath::try_with("config.toml") {
         Ok(config) => {
-            assert!(config.path().ends_with("config.toml"));
+            assert!(config.ends_with("config.toml"));
         }
         Err(_e) => {
             // In our test environment, this shouldn't happen
@@ -80,7 +80,7 @@ fn test_fallible_api_documentation_examples() {
     }
 
     let config = load_config().unwrap();
-    assert!(config.path().ends_with("config.toml"));
+    assert!(config.ends_with("config.toml"));
 
     // Example 3: Fallback strategy
     fn get_config_with_fallback() -> AppPath {
@@ -92,7 +92,7 @@ fn test_fallible_api_documentation_examples() {
 
     let config = get_config_with_fallback();
     // Should succeed in either case
-    assert!(config.path().is_absolute());
+    assert!(config.is_absolute());
 }
 
 #[test]

--- a/src/tests/macros.rs
+++ b/src/tests/macros.rs
@@ -12,11 +12,11 @@ fn test_app_path_macro_no_params() {
     // Should match what std::env::current_exe() tells us (independent verification)
     let current_exe = std::env::current_exe().unwrap();
     let exe_parent = current_exe.parent().unwrap();
-    assert_eq!(app_base.path(), exe_parent);
+    assert_eq!(&*app_base, exe_parent);
 
     // Should be consistent across multiple calls (caching behavior)
     let app_base2 = app_path!();
-    assert_eq!(app_base.path(), app_base2.path());
+    assert_eq!(app_base, app_base2);
 
     // Should be a directory, not a file
     assert!(app_base.is_dir());
@@ -26,7 +26,7 @@ fn test_app_path_macro_no_params() {
 fn test_app_path_macro_basic() {
     let config = app_path!("config.toml");
     let expected = AppPath::with("config.toml");
-    assert_eq!(config.path(), expected.path());
+    assert_eq!(config, expected);
 }
 
 #[test]
@@ -36,7 +36,7 @@ fn test_app_path_macro_with_env() {
     env::set_var("TEST_CONFIG_PATH", &custom_path);
 
     let config = app_path!("default.toml", env = "TEST_CONFIG_PATH");
-    assert_eq!(config.path(), custom_path);
+    assert_eq!(&*config, &custom_path);
 
     // Test with non-existent env var
     let default_config = app_path!("default.toml", env = "NON_EXISTENT_VAR");
@@ -45,7 +45,7 @@ fn test_app_path_macro_with_env() {
         .parent()
         .unwrap()
         .join("default.toml");
-    assert_eq!(default_config.path(), expected);
+    assert_eq!(&*default_config, &expected);
 
     env::remove_var("TEST_CONFIG_PATH");
 }
@@ -55,7 +55,7 @@ fn test_app_path_macro_with_override() {
     let temp_dir = env::temp_dir();
     let override_path = temp_dir.join("custom_path.toml");
     let config = app_path!("default.toml", override = Some(override_path.clone()));
-    assert_eq!(config.path(), override_path);
+    assert_eq!(&*config, &override_path);
 
     let no_override: Option<PathBuf> = None;
     let default_config = app_path!("default.toml", override = no_override);
@@ -64,7 +64,7 @@ fn test_app_path_macro_with_override() {
         .parent()
         .unwrap()
         .join("default.toml");
-    assert_eq!(default_config.path(), expected);
+    assert_eq!(&*default_config, &expected);
 }
 
 #[test]
@@ -73,7 +73,7 @@ fn test_app_path_macro_with_fn() {
 
     // Test fn variant that returns Some
     let config = app_path!("default.toml", fn = || Some(custom_path.clone()));
-    assert_eq!(config.path(), custom_path);
+    assert_eq!(&*config, &custom_path);
 
     // Test fn variant that returns None
     let default_config = app_path!("default.toml", fn = || None::<PathBuf>);
@@ -82,7 +82,7 @@ fn test_app_path_macro_with_fn() {
         .parent()
         .unwrap()
         .join("default.toml");
-    assert_eq!(default_config.path(), expected);
+    assert_eq!(&*default_config, &expected);
 
     // Test fn variant with complex logic
     let complex_config = app_path!("config.toml", fn = || {
@@ -97,7 +97,7 @@ fn test_app_path_macro_with_fn() {
         .parent()
         .unwrap()
         .join("config.toml");
-    assert_eq!(complex_config.path(), expected_complex);
+    assert_eq!(&*complex_config, &expected_complex);
 }
 
 // === try_app_path! Macro Tests ===
@@ -115,11 +115,11 @@ fn test_try_app_path_macro_no_params() {
     // Should match what std::env::current_exe() tells us (independent verification)
     let current_exe = std::env::current_exe().unwrap();
     let exe_parent = current_exe.parent().unwrap();
-    assert_eq!(app_base.path(), exe_parent);
+    assert_eq!(&*app_base, exe_parent);
 
     // Should be consistent with panicking version
     let panicking_version = app_path!();
-    assert_eq!(app_base.path(), panicking_version.path());
+    assert_eq!(app_base, panicking_version);
 
     // Should be a directory, not a file
     assert!(app_base.is_dir());
@@ -129,7 +129,7 @@ fn test_try_app_path_macro_no_params() {
 fn test_try_app_path_macro_basic() {
     let config = try_app_path!("config.toml").unwrap();
     let expected = AppPath::try_with("config.toml").unwrap();
-    assert_eq!(config.path(), expected.path());
+    assert_eq!(config, expected);
 }
 
 #[test]
@@ -139,7 +139,7 @@ fn test_try_app_path_macro_with_env() {
     env::set_var("TEST_TRY_CONFIG_PATH", &custom_path);
 
     let config = try_app_path!("default.toml", env = "TEST_TRY_CONFIG_PATH").unwrap();
-    assert_eq!(config.path(), custom_path);
+    assert_eq!(&*config, &custom_path);
 
     // Test with non-existent env var
     let default_config = try_app_path!("default.toml", env = "NON_EXISTENT_VAR").unwrap();
@@ -148,7 +148,7 @@ fn test_try_app_path_macro_with_env() {
         .parent()
         .unwrap()
         .join("default.toml");
-    assert_eq!(default_config.path(), expected);
+    assert_eq!(&*default_config, &expected);
 
     env::remove_var("TEST_TRY_CONFIG_PATH");
 }
@@ -158,7 +158,7 @@ fn test_try_app_path_macro_with_override() {
     let temp_dir = env::temp_dir();
     let override_path = temp_dir.join("custom_path.toml");
     let config = try_app_path!("default.toml", override = Some(override_path.clone())).unwrap();
-    assert_eq!(config.path(), override_path);
+    assert_eq!(&*config, &override_path);
 
     let no_override: Option<PathBuf> = None;
     let default_config = try_app_path!("default.toml", override = no_override).unwrap();
@@ -167,7 +167,7 @@ fn test_try_app_path_macro_with_override() {
         .parent()
         .unwrap()
         .join("default.toml");
-    assert_eq!(default_config.path(), expected);
+    assert_eq!(&*default_config, &expected);
 }
 
 #[test]
@@ -176,7 +176,7 @@ fn test_try_app_path_macro_with_fn() {
 
     // Test fn variant that returns Some
     let config = try_app_path!("default.toml", fn = || Some(custom_path.clone())).unwrap();
-    assert_eq!(config.path(), custom_path);
+    assert_eq!(&*config, &custom_path);
 
     // Test fn variant that returns None
     let default_config = try_app_path!("default.toml", fn = || None::<PathBuf>).unwrap();
@@ -185,7 +185,7 @@ fn test_try_app_path_macro_with_fn() {
         .parent()
         .unwrap()
         .join("default.toml");
-    assert_eq!(default_config.path(), expected);
+    assert_eq!(&*default_config, &expected);
 
     // Test fn variant with complex logic
     let complex_config = try_app_path!("config.toml", fn = || {
@@ -201,7 +201,7 @@ fn test_try_app_path_macro_with_fn() {
         .parent()
         .unwrap()
         .join("config.toml");
-    assert_eq!(complex_config.path(), expected_complex);
+    assert_eq!(&*complex_config, &expected_complex);
 }
 
 #[test]
@@ -213,7 +213,7 @@ fn test_try_app_path_macro_returns_result() {
     // Test error handling pattern
     match try_app_path!("test.toml") {
         Ok(path) => {
-            assert!(path.path().ends_with("test.toml"));
+            assert!(path.ends_with("test.toml"));
         }
         Err(_) => panic!("Should not fail in normal conditions"),
     }
@@ -224,20 +224,20 @@ fn test_try_app_path_vs_app_path_equivalence() {
     // The successful results should be equivalent
     let panicking = app_path!("config.toml");
     let fallible = try_app_path!("config.toml").unwrap();
-    assert_eq!(panicking.path(), fallible.path());
+    assert_eq!(panicking, fallible);
 
     // Test with env override
     env::set_var("TEST_EQUIV_PATH", "/tmp/test.conf");
     let panicking_env = app_path!("default.conf", env = "TEST_EQUIV_PATH");
     let fallible_env = try_app_path!("default.conf", env = "TEST_EQUIV_PATH").unwrap();
-    assert_eq!(panicking_env.path(), fallible_env.path());
+    assert_eq!(panicking_env, fallible_env);
     env::remove_var("TEST_EQUIV_PATH");
 
     // Test with custom override
     let override_path = Some(PathBuf::from("/custom/path.conf"));
     let panicking_override = app_path!("default.conf", override = override_path.clone());
     let fallible_override = try_app_path!("default.conf", override = override_path).unwrap();
-    assert_eq!(panicking_override.path(), fallible_override.path());
+    assert_eq!(panicking_override, fallible_override);
 }
 
 #[test]
@@ -245,13 +245,13 @@ fn test_macro_fn_variants_equivalence() {
     // Test that both macros produce equivalent results when function returns None
     let panicking_fn = app_path!("test.toml", fn = || None::<String>);
     let fallible_fn = try_app_path!("test.toml", fn = || None::<String>).unwrap();
-    assert_eq!(panicking_fn.path(), fallible_fn.path());
+    assert_eq!(panicking_fn, fallible_fn);
 
     // Test with function that returns Some
     let custom_path = env::temp_dir().join("equiv_test.toml");
     let panicking_fn_some = app_path!("test.toml", fn = || Some(custom_path.clone()));
     let fallible_fn_some = try_app_path!("test.toml", fn = || Some(custom_path.clone())).unwrap();
-    assert_eq!(panicking_fn_some.path(), fallible_fn_some.path());
+    assert_eq!(panicking_fn_some, fallible_fn_some);
 }
 
 #[test]
@@ -269,14 +269,14 @@ fn test_fn_variant_with_real_xdg_logic() {
     let config_try_app_path = try_app_path!("config.toml", fn = get_config_path).unwrap();
 
     // Both should use the same path, whether it's XDG or default
-    assert_eq!(config_app_path.path(), config_try_app_path.path());
+    assert_eq!(config_app_path, config_try_app_path);
 
     // Check if XDG logic would be used
     if env::var("XDG_CONFIG_HOME").is_ok() || env::var("HOME").is_ok() {
         // If XDG variables are available, should use the XDG path
         let xdg_result = get_config_path();
         if let Some(xdg_path) = xdg_result {
-            assert_eq!(config_app_path.path(), xdg_path);
+            assert_eq!(&*config_app_path, &xdg_path);
         }
     } else {
         // If no XDG variables, should use default path
@@ -285,6 +285,6 @@ fn test_fn_variant_with_real_xdg_logic() {
             .parent()
             .unwrap()
             .join("config.toml");
-        assert_eq!(config_app_path.path(), expected);
+        assert_eq!(&*config_app_path, &expected);
     }
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,9 +1,6 @@
 // Test modules for app-path
 // Organized by functionality for better maintainability
 
-// Allow deprecated warnings in tests during migration period
-#![allow(deprecated)]
-
 mod basic;
 mod constructors;
 mod directory_creation;

--- a/src/tests/path_manipulation.rs
+++ b/src/tests/path_manipulation.rs
@@ -53,7 +53,7 @@ fn test_parent() {
     let parent_of_root = root_file.parent().unwrap();
     // Parent should be the exe directory
     assert_eq!(
-        parent_of_root.path(),
+        &*parent_of_root,
         std::env::current_exe().unwrap().parent().unwrap()
     );
 }
@@ -290,10 +290,7 @@ fn test_root_file_manipulation() {
 
     // Should be able to get parent (exe directory)
     let parent = root_file.parent().unwrap();
-    assert_eq!(
-        parent.path(),
-        std::env::current_exe().unwrap().parent().unwrap()
-    );
+    assert_eq!(&*parent, std::env::current_exe().unwrap().parent().unwrap());
 
     // Should be able to change extension
     let json_version = root_file.with_extension("json");


### PR DESCRIPTION
# Release v1.0.1 - Maintenance Update

## 📋 Summary

This patch release completes the deprecation cycle for the `.path()` method and includes various maintenance improvements to keep the codebase clean and up-to-date.

## 🧹 Changes

### Maintenance
- **Removed deprecated `.path()` method** - Completed deprecation cycle started in v0.2.7, method fully removed from codebase
- **Updated tests** - Migrated all test code from deprecated `.path()` to modern deref patterns (`&app_path`)
- **Improved documentation examples** - Corrected and clarified examples throughout the codebase

### Documentation
- **Enhanced code examples** - Better clarity and accuracy in documentation examples
- **Test suite cleanup** - Ensured all tests use current API patterns without deprecated methods

## 🔄 Migration Guide

No action required for users - the `.path()` method was deprecated in v0.2.7 and users should already be using direct deref patterns (`&app_path`) or `as_ref()`.

## ✅ Testing

- All existing tests pass with updated API usage
- No breaking changes to public API
- Maintains full backward compatibility (except for removed deprecated method)

## 📦 Version Bump

- Version updated from `1.0.0` to `1.0.1`
- Appropriate semantic versioning for maintenance