### PR TITLE
Release v1.1.1: Documentation cleanup and keyword optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.1] - 2025-07-22
+
+### 📚 **Documentation & Discoverability Improvements**
+
+#### **Enhanced Documentation**
+- **Streamlined README.md**: Removed redundant `try_app_path!` examples that duplicated `app_path!` syntax
+- **Focused Constructor API**: Removed `try_*` method examples, keeping only core non-try methods
+- **Improved keyword discoverability**: Updated crate keywords to include "config" for better search results
+- **Completed function-based override documentation**: Added missing `try_with_override_fn()` examples across all API sections
+- **Cleaner "See Also" references**: Added complete constructor references in macro documentation
+
+#### **Benefits for Users**
+- **Reduced documentation bloat**: Eliminated 15+ lines of redundant examples
+- **Clearer focus**: Documentation now highlights primary usage patterns without obvious variants
+- **Better discoverability**: Improved crate findability for configuration file use cases
+- **Complete API coverage**: All function-based override patterns now properly documented
+
+>>>>>>> dev
 ## [1.1.0] - 2025-07-21
 
 ### 🚀 **Enhanced Error Handling**

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app-path"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 authors = ["David Krasnitsky <dikaveman@gmail.com>"]
 description = "Create file paths relative to your executable for truly portable applications"
@@ -9,7 +9,7 @@ repository = "https://github.com/DK26/app-path-rs"
 homepage = "https://github.com/DK26/app-path-rs"
 documentation = "https://docs.rs/app-path"
 readme = "README.md"
-keywords = ["filesystem", "portable", "path", "executable", "cross-platform"]
+keywords = ["filesystem", "portable", "path", "executable", "config"]
 categories = ["filesystem", "development-tools"]
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -87,22 +87,7 @@ app_path!("logs/app.log").create_parents()?;  // Creates `logs/` for the `app.lo
 app_path!("temp").create_dir()?;  // Creates `temp/` directory itself
 ```
 
-### Fallible `try_app_path!` Macro
-
-```rust
-use app_path::try_app_path;
-
-// Fallible base directory
-let app_base = try_app_path!()?;  
-let config = try_app_path!("config.toml")?;
-let database = try_app_path!("data/users.db", env = "DATABASE_PATH")?;
-
-// Error handling
-match try_app_path!("logs/app.log") {
-    Ok(log_path) => log_path.create_parents()?,
-    Err(e) => eprintln!("Failed: {e}"),
-}
-```
+> **Note**: Use `try_app_path!` instead of `app_path!` when you need `Result` return values for explicit error handling (same syntax, just returns `Result<AppPath, AppPathError>` instead of panicking).
 
 ### Constructor API
 
@@ -112,11 +97,19 @@ use app_path::AppPath;
 // Basic constructors
 let app_base = AppPath::new();                       // Executable directory
 let config = AppPath::with("config.toml");           // App base + path
-let database = AppPath::try_with("data/users.db")?;  // Fallible version
 
 // Override constructors
 let config = AppPath::with_override("config.toml", std::env::var("CONFIG_PATH").ok());
-let database = AppPath::try_with_override("data/users.db", std::env::var("DB_PATH").ok())?;
+
+// Function-based override constructors
+let logs = AppPath::with_override_fn("logs", || {
+    std::env::var("XDG_STATE_HOME")
+        .or_else(|_| std::env::var("HOME").map(|h| format!("{h}/.local/state/myapp")))
+        .ok()
+});
+```
+
+> **Note**: All constructors have `try_*` variants that return `Result` instead of panicking (e.g., `try_new()`, `try_with()`, `try_with_override()`, `try_with_override_fn()`).
 ```
 
 ## Real-World Examples

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -341,6 +341,7 @@ macro_rules! app_path {
 /// - [`app_path!`] - Panicking version with identical syntax
 /// - [`AppPath::try_new()`] - Constructor equivalent
 /// - [`AppPath::try_with_override()`] - Constructor with override equivalent
+/// - [`AppPath::try_with_override_fn()`] - Constructor with function-based override equivalent
 #[macro_export]
 macro_rules! try_app_path {
     () => {


### PR DESCRIPTION
# Release v1.1.1: Documentation cleanup and keyword optimization

## Changes

### Documentation
- **Removed redundant examples** from README.md that duplicated `try_*` methods unnecessarily
- **Enhanced macro documentation** with complete constructor references in `try_app_path!`

### Keywords  
- **Replaced `"cross-platform"` with `"config"`** for better crates.io discoverability

## Impact

- **Cleaner documentation** - Less verbose, more focused examples
- **Better search results** - More specific keyword targeting for common use cases
- **No API changes** - Pure documentation and metadata improvements

Simple patch release that makes the crate easier to discover and the docs easier to read.